### PR TITLE
feat: Add PKGBUILD for Arch Linux installation

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,22 @@
+# Maintainer: Your Name <youremail@domain.com>
+pkgname=commit-craft
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="A tool to craft commit messages."
+arch=('x86_64')
+url="https://github.com/Starrick2001/commit-craft"
+license=('MIT')
+depends=('git')
+makedepends=('go')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  go build -o "$pkgname"
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+  install -Dm755 "$pkgname" "$pkgdir/usr/bin/$pkgname"
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Commit Craft is a Go-based tool that leverages the Gemini API to automatically g
    sudo mv commit-craft /usr/local/bin/
    ```
 
+### Arch Linux (from source)
+Alternatively, Arch Linux users can build and install the package using the provided PKGBUILD file:
+```bash
+git clone https://github.com/Starrick2001/commit-craft.git
+cd commit-craft
+makepkg -si
+```
+
 ## Setup
 
 Set up your Gemini API Key as an environment variable:


### PR DESCRIPTION
This commit introduces a PKGBUILD file, enabling Arch Linux users to easily build and install the commit-craft tool from source using `makepkg`. It also updates the README with instructions for Arch Linux installation.